### PR TITLE
위키페이지 주소로 가기

### DIFF
--- a/src/main/resources/static/bower.json
+++ b/src/main/resources/static/bower.json
@@ -18,7 +18,8 @@
     "mobile-detect": "1.3.5",
     "moment": "2.17.1",
     "perfect-scrollbar": "0.6.14",
-    "datatables-responsive": "2.1.0"
+    "datatables-responsive": "2.1.0",
+    "angular-swx-session-storage": "1.0.2"
   },
   "devDependencies": {
     "angular-mocks": "1.5.11"

--- a/src/main/resources/static/bower.json
+++ b/src/main/resources/static/bower.json
@@ -19,7 +19,7 @@
     "moment": "2.17.1",
     "perfect-scrollbar": "0.6.14",
     "datatables-responsive": "2.1.0",
-    "angular-swx-session-storage": "1.0.2"
+    "angular-swx-session-storage": "^1.0.2"
   },
   "devDependencies": {
     "angular-mocks": "1.5.11"

--- a/src/main/resources/static/package.json
+++ b/src/main/resources/static/package.json
@@ -15,6 +15,7 @@
     "test": "gulp test"
   },
   "devDependencies": {
+    "angular-swx-session-storage": "^1.0.0",
     "browser-sync": "~2.9.11",
     "browser-sync-spa": "~1.0.3",
     "chalk": "~1.1.1",

--- a/src/main/resources/static/package.json
+++ b/src/main/resources/static/package.json
@@ -2,6 +2,7 @@
   "name": "fuse",
   "version": "1.4.5",
   "dependencies": {
+    "angular-swx-session-storage": "^1.0.0",
     "body-parser": "^1.16.1",
     "cookie-parser": "^1.4.3",
     "ejs": "^2.5.5",
@@ -15,7 +16,6 @@
     "test": "gulp test"
   },
   "devDependencies": {
-    "angular-swx-session-storage": "^1.0.0",
     "browser-sync": "~2.9.11",
     "browser-sync-spa": "~1.0.3",
     "chalk": "~1.1.1",

--- a/src/main/resources/static/src/app/data/quick-panel/recentwiki.json
+++ b/src/main/resources/static/src/app/data/quick-panel/recentwiki.json
@@ -1,31 +1,47 @@
-{
-    "data": {
-        "change": [
-            {
-                "name": "산학관",
-                "message": "1-1 위치 항목이 수정되었습니다.",
-                "time": "5/3 4:40 AM"
-            },
-            {
-                "name": "산학관",
-                "message": "1-1 위치 항목이 수정되었습니다.",
-                "time": "5/3 4:40 AM"
-            },
-            {
-                "name": "산학관",
-                "message": "1-1 위치 항목이 수정되었습니다.",
-                "time": "5/3 4:40 AM"
-            },
-            {
-                "name": "산학관",
-                "message": "1-1 위치 항목이 수정되었습니다.",
-                "time": "5/3 4:40 AM"
-            },
-            {
-                "name": "산학관",
-                "message": "1-1 위치 항목이 수정되었습니다.",
-                "time": "5/3 4:40 AM"
-            }
-        ]
+
+[
+    {
+      "id": 109,
+      "category": {
+        "id": 2,
+        "name": "skku",
+        "page_id": 0,
+        "last_num": 35469
+      },
+      "location": {
+        "id": 1,
+        "name": "복지회관",
+        "center_lng": 37.29400634392711,
+        "center_lat": 126.97257459376289,
+        "type": "admin",
+        "shape": null
+      },
+      "title": "2017하계 SNEC 수강안내 (국제품 취득을 위한 집중 토익캠프)",
+      "contents": "○ SNEC (SKKU Natural sciences campus English Camp) 이란? \n본교 재학생의 국제품 취득 관련 어학능력함양을 목적으로 \n 자과캠 어학원에서 15일 동안 집중적으로 실용영어능력을 배양하는 프로그램 \n\n○ 대상: 본교 학부생(재학생, 휴학생) / 수료생 \n\n○ 교육일정 및 내용 \n- 기 간: 2017. 6. 22(목) ~ 2017. 7. 12(수) (15일간) \n- 수업시간: 09:00 ~ 12:20 \n- 장 소: 자연과학캠퍼스 \n- 과 정: Toeic RC, Toeic LC, Toeic Speaking \n\n○ 모집인원: 60명(선착순 마감) \n\n○ 신청기간: 2017.  5. 29(월) ~ 6. 9(금) \n\n○ 접 수 처: (자)성균어학원 (031-290-5232) \n- 접수방법: 성균어학원 홈페이지 온라인 지원 \nhttp://home.skku.edu/~sli → 로그인 → 강좌접수 → SNEC → 수강신청 \n\n○ 수 강 료: 320,000원 \n- 수강료 납부: 수강신청 후 가상계좌로 입금 (타 결제방식 사용불가) \n- 환불규정 \n; 수업 개시 전 - 100% 환불 \n; 수업 개시 후 - 계절수업 수강료 반환기준에 의거 환불처리(수업일수 3/4경과후는 환불액 없음) \n\n○ 오리엔테이션 : 2017. 6. 22(목) 09:00 / 자과캠 제2공학관 1층 27112호 \n\n○ 평가 및 수료 \n- 전체 70점(출석 60% / 평가시험 40%) 이상 획득시 PASS \n- 본 과정을 PASS한 자는 수료증 수여 \n- 한 과목 당 통산 3시간 초과 결석하는 경우 과정 미수료 \n- 한 과목이라도 FAIL 하는 경우 과정 미수료 \n\n○ 프로그램 특징 \n- 우리대학 외국인 교원이 직접 TOEIC 지도 \n- 본 과정을 수료한 학생 중 국제품 희망 시 국제품 취득자격 부여 \n\n\n성 균 어 학 원",
+      "time": 1495771203000,
+      "link": "http://www.skku.edu/new_home/campus/skk_comm/notice_view.jsp?bCode=0&page=1&boardNum=35469&virtualNum=0&skey=BOARD_SUBJECT&keyword=&bName=board_news&bCode=0",
+      "img_src": ""
+    },
+    {
+      "id": 109,
+      "category": {
+        "id": 2,
+        "name": "skku",
+        "page_id": 0,
+        "last_num": 35469
+      },
+      "location": {
+        "id": 1,
+        "name": "복지회관",
+        "center_lng": 37.29400634392711,
+        "center_lat": 126.97257459376289,
+        "type": "admin",
+        "shape": null
+      },
+      "title": "2017하계 SNEC 수강안내 (국제품 취득을 위한 집중 토익캠프)",
+      "contents": "○ SNEC (SKKU Natural sciences campus English Camp) 이란? \n본교 재학생의 국제품 취득 관련 어학능력함양을 목적으로 \n 자과캠 어학원에서 15일 동안 집중적으로 실용영어능력을 배양하는 프로그램 \n\n○ 대상: 본교 학부생(재학생, 휴학생) / 수료생 \n\n○ 교육일정 및 내용 \n- 기 간: 2017. 6. 22(목) ~ 2017. 7. 12(수) (15일간) \n- 수업시간: 09:00 ~ 12:20 \n- 장 소: 자연과학캠퍼스 \n- 과 정: Toeic RC, Toeic LC, Toeic Speaking \n\n○ 모집인원: 60명(선착순 마감) \n\n○ 신청기간: 2017.  5. 29(월) ~ 6. 9(금) \n\n○ 접 수 처: (자)성균어학원 (031-290-5232) \n- 접수방법: 성균어학원 홈페이지 온라인 지원 \nhttp://home.skku.edu/~sli → 로그인 → 강좌접수 → SNEC → 수강신청 \n\n○ 수 강 료: 320,000원 \n- 수강료 납부: 수강신청 후 가상계좌로 입금 (타 결제방식 사용불가) \n- 환불규정 \n; 수업 개시 전 - 100% 환불 \n; 수업 개시 후 - 계절수업 수강료 반환기준에 의거 환불처리(수업일수 3/4경과후는 환불액 없음) \n\n○ 오리엔테이션 : 2017. 6. 22(목) 09:00 / 자과캠 제2공학관 1층 27112호 \n\n○ 평가 및 수료 \n- 전체 70점(출석 60% / 평가시험 40%) 이상 획득시 PASS \n- 본 과정을 PASS한 자는 수료증 수여 \n- 한 과목 당 통산 3시간 초과 결석하는 경우 과정 미수료 \n- 한 과목이라도 FAIL 하는 경우 과정 미수료 \n\n○ 프로그램 특징 \n- 우리대학 외국인 교원이 직접 TOEIC 지도 \n- 본 과정을 수료한 학생 중 국제품 희망 시 국제품 취득자격 부여 \n\n\n성 균 어 학 원",
+      "time": 1495771203000,
+      "link": "http://www.skku.edu/new_home/campus/skk_comm/notice_view.jsp?bCode=0&page=1&boardNum=35469&virtualNum=0&skey=BOARD_SUBJECT&keyword=&bName=board_news&bCode=0",
+      "img_src": ""
     }
-}
+]

--- a/src/main/resources/static/src/app/index.controller.js
+++ b/src/main/resources/static/src/app/index.controller.js
@@ -7,9 +7,10 @@
         .controller('IndexController', IndexController);
 
     /** @ngInject */
-    function IndexController(fuseTheming)
+    function IndexController(fuseTheming, $rootScope)
     {
         var vm = this;
+        $rootScope.wikipath = "http://fanatic1.iptime.org:8080/xwiki/bin/view/XWiki/";
 
         // Data
         vm.themes = fuseTheming.themes;

--- a/src/main/resources/static/src/app/index.route.js
+++ b/src/main/resources/static/src/app/index.route.js
@@ -31,44 +31,38 @@
                     }
                 },
                 resolve: {
-                    /*
-                    TimelineData: function (msApi)
-                    {
-                        return msApi.resolve('quickPanel.timeline@get');
-                    },
-                    */
                     TimelineData: function ($http)
                     {
-                        var obj = {content:null};
-                        $http.get('app/data/quick-panel/timeline.json').then(function (response){
-                            obj.content = response;
-                        });
+                        //임시
+                        var obj = $http.get('/app/data/quick-panel/timeline.json');
                         return obj;
                     },
                     PeerData: function ($http)
                     {
-                        var obj = {content:null};
-                        $http.get('app/data/quick-panel/peer.json').then(function (response){
-                            obj.content = response;
-                        });
+                        //임시
+                        var obj = $http.get('/app/data/quick-panel/peer.json');
                         return obj;
                     },
                     RequestData: function ($http)
                     {
-                        var obj = {content:null};
-                        $http.get('app/data/quick-panel/request.json').then(function (response){
-                            obj.content = response;
-                        });
+                        //임시
+                        var obj = $http.get('/app/data/quick-panel/request.json');
                         return obj;
                     },
+                    Notice: function ($http)
+                    {
+                        //임시
+                        var obj = $http.get('/app/data/quick-panel/recentwiki.json');
+                        return obj;
+                    },
+                    
                     RecentwikiData: function ($http)
                     {
-                        var obj = {content:null};
-                        $http.get('app/data/quick-panel/recentwiki.json').then(function (response){
-                            obj.content = response;
-                        });
+                        var obj;
+                        //obj = $http.get('http://fanatic1.iptime.org:8080/xwiki/rest/wikis/xwiki/modifications?start=0&number=30');
                         return obj;
                     }
+                    
                 }
             });
     }

--- a/src/main/resources/static/src/app/main/login/login.controller.js
+++ b/src/main/resources/static/src/app/main/login/login.controller.js
@@ -7,7 +7,8 @@
         .controller('LoginController', LoginController);
 
     /** @ngInject */
-    function LoginController($state, $rootScope)
+
+    function LoginController($state, $rootScope, $sessionStorage)
     {
         // Data
         var vm = this;
@@ -16,8 +17,9 @@
         // Methods
         vm.loginfun = function (email,password) {
 
-            //서버에 email, password 보내서 확인 받기
-            $rootScope.email = email;
+            //서버에 email, password 보내서 확인 받기 필요
+            //받은 후 아래 작업 실행
+            $sessionStorage.put('useremail', email, 0.5);
             $state.go('app.map');
         };
 

--- a/src/main/resources/static/src/app/main/login/login.module.js
+++ b/src/main/resources/static/src/app/main/login/login.module.js
@@ -3,7 +3,7 @@
     'use strict';
 
     angular
-        .module('app.login', [])
+        .module('app.login', ['swxSessionStorage'])
         .config(config);
 
     /** @ngInject */

--- a/src/main/resources/static/src/app/main/map/map.controller.js
+++ b/src/main/resources/static/src/app/main/map/map.controller.js
@@ -9,7 +9,7 @@
 
 
     /** @ngInject */
-    function MapController($mdDialog, CustomEventMarkerData, SubAreaData, CategoryMarkerData, MarkerData, $scope, $interval, $timeout, peerLocation, mapLocation)
+    function MapController($mdDialog, CustomEventMarkerData, SubAreaData, CategoryMarkerData, MarkerData, $scope, $interval, $timeout, peerLocation, mapLocation, $sessionStorage, $state)
     {
         var vm = this;
         vm.markerData = MarkerData.data;
@@ -54,6 +54,18 @@
                 vm.customEvnetTooltipVisible = vm.customEventIsOpen;
             }
         }, true);
+
+        //로그인 되어있지 않은 사용자가 맵에 접근시 로그인 페이지로 돌려보냄
+        
+        function usercheck(){
+            var userval = $sessionStorage.get('useremail');
+            if(userval == undefined){
+                alert('로그인 되어 있지 않거나 세션 유효기간이 끝나 로그아웃 되었습니다.');
+                $state.go('login');
+            }
+        };
+        usercheck();
+
 
 
         var drawCustomEvnetOptions = { // Drawing Manager를 생성할 때 사용할 옵션입니다

--- a/src/main/resources/static/src/app/main/notice/notice-content/facebook/facebook.controller.js
+++ b/src/main/resources/static/src/app/main/notice/notice-content/facebook/facebook.controller.js
@@ -7,9 +7,19 @@
         .controller('FacebookController', FacebookController);
 
     /** @ngInject */
-    function FacebookController(FacebookData)
+    function FacebookController(FacebookData, $sessionStorage, $state)
     {
         var vm = this;
+
+        //로그인 되어있지 않은 사용자가 공지사항에 접근시 로그인 페이지로 돌려보냄
+        function usercheck(){
+            var userval = $sessionStorage.get('useremail');
+            if(userval == undefined){
+                alert('로그인 되어 있지 않거나 세션 유효기간이 끝나 로그아웃 되었습니다.');
+                $state.go('login');
+            }
+        };
+        usercheck();
 
         vm.dtOptions = {
             dom       : '<"top"f>rt<"bottom"<"left"<"length"l>><"right"<"info"i><"pagination"p>>>',

--- a/src/main/resources/static/src/app/main/notice/notice.controller.js
+++ b/src/main/resources/static/src/app/main/notice/notice.controller.js
@@ -7,8 +7,18 @@
         .controller('NoticeController', NoticeController);
 
     /** @ngInject */
-    function NoticeController($scope, $timeout)
+    function NoticeController($scope, $timeout, $sessionStorage, $state)
     {
     	var vm = this;
+
+    	//로그인 되어있지 않은 사용자가 공지사항에 접근시 로그인 페이지로 돌려보냄
+    	function usercheck(){
+            var userval = $sessionStorage.get('useremail');
+            if(userval == undefined){
+                alert('로그인 되어 있지 않거나 세션 유효기간이 끝나 로그아웃 되었습니다.');
+                $state.go('login');
+            }
+        };
+        usercheck();
     }
 })();

--- a/src/main/resources/static/src/app/main/wiki/wiki.controller.js
+++ b/src/main/resources/static/src/app/main/wiki/wiki.controller.js
@@ -7,10 +7,15 @@
         .controller('WikiController', WikiController);
 
     /** @ngInject */
-    function WikiController()
+    function WikiController($sce, $rootScope)
     {
         var vm = this;
+        vm.path = $rootScope.wikipath
+        console.log(vm.path);
 
+        vm.getUrl = function () {
+            return $sce.trustAsResourceUrl(vm.path);
+        };
        
     }
 })();

--- a/src/main/resources/static/src/app/main/wiki/wiki.controller.js
+++ b/src/main/resources/static/src/app/main/wiki/wiki.controller.js
@@ -7,11 +7,20 @@
         .controller('WikiController', WikiController);
 
     /** @ngInject */
-    function WikiController($sce, $rootScope)
+    function WikiController($sce, $rootScope, $sessionStorage, $state)
     {
         var vm = this;
         vm.path = $rootScope.wikipath
-        console.log(vm.path);
+        
+        //로그인 되어있지 않은 사용자가 위키에 접근시 로그인 페이지로 돌려보냄
+        function usercheck(){
+            var userval = $sessionStorage.get('useremail');
+            if(userval == undefined){
+                alert('로그인 되어 있지 않거나 세션 유효기간이 끝나 로그아웃 되었습니다.');
+                $state.go('login');
+            }
+        };
+        usercheck();
 
         vm.getUrl = function () {
             return $sce.trustAsResourceUrl(vm.path);

--- a/src/main/resources/static/src/app/main/wiki/wiki.html
+++ b/src/main/resources/static/src/app/main/wiki/wiki.html
@@ -1,1 +1,1 @@
-<iframe frameborder=" 0" id="domainframe" src="http://fanatic1.iptime.org:8080/xwiki/bin/view/XWiki/" width="100%" height = "100%" scrolling="auto";></iframe>
+<iframe frameborder=" 0" ng-src="{{vm.getUrl()}}" width="100%" height = "100%" scrolling="auto";></iframe>

--- a/src/main/resources/static/src/app/quick-panel/quick-panel.controller.js
+++ b/src/main/resources/static/src/app/quick-panel/quick-panel.controller.js
@@ -7,14 +7,15 @@
         .controller('QuickPanelController', QuickPanelController);
 
     /** @ngInject */
-    function QuickPanelController(peerLocation, TimelineData, PeerData, RequestData, RecentwikiData)
+    function QuickPanelController(peerLocation, TimelineData, PeerData, RequestData, RecentwikiData, $http, Notice, $rootScope, $state)
     {
         var vm = this;
 
-        vm.timeline = TimelineData.content.data.data;
-        vm.peer = PeerData.content.data.data;
-        vm.request = RequestData.content.data.data;
-        vm.recentwiki = RecentwikiData.content.data.data;
+        vm.timeline = TimelineData.data.data;
+        vm.peer = PeerData.data.data;
+        vm.request = RequestData.data.data;
+
+        //vm.recentwiki = RecentwikiData.data;
 
         vm.currenttimeline = "SE";
         vm.currentlocation = "ST";
@@ -31,8 +32,12 @@
             PF : []
         };
 
-        
+        vm.wikihistory = {
+            Name : [],
+            Link : []
+        };
 
+        
         vm.findtimelinelocation = function (event) {
             //구역 ID로 이동
             peerLocation.eventlocation = event.location;
@@ -52,7 +57,42 @@
                     vm.toggle(vm.peer.location["PF"][value],vm.selected["PF"]);
                 }
             }
+
+            //vm.getWikiLink();
         };
+        
+        vm.getWikiLink = function () 
+        {
+            
+            for (var i=0; i<vm.recentwiki.historySummaries.length; i++){
+                if((vm.wikihistory.Name.indexOf(vm.recentwiki.historySummaries[i].pageId) == -1) && (vm.recentwiki.historySummaries[i].space.substring(0,6)=="XWiki."))
+                {
+                    vm.wikihistory.Name.push(vm.recentwiki.historySummaries[i].pageId);
+                    var obj = {};
+                    obj.Title = vm.recentwiki.historySummaries[i].space.substring(6);
+                    obj.Link = 'http://fanatic1.iptime.org:8080/xwiki/bin/view/XWiki/' + vm.recentwiki.historySummaries[i].space.substring(6);
+                    vm.wikihistory.Link.push(obj);
+                }
+            }
+        };
+
+        vm.wikigo = function (wikilink) 
+        {
+            //wiki state일 때는 reload, 아닐때는 wikistate로
+
+            $rootScope.wikipath=wikilink;
+
+            if($state.includes('app.wiki') == true)
+            {
+                $state.reload();
+            }
+            else
+            {
+                $state.go('app.wiki');
+            }
+            
+        };
+        
 
         vm.toggle = function (peer, list) {
             var idx = list.indexOf(peer.weight);
@@ -134,9 +174,7 @@
 
         init();
 
-        // Methods
-
-        //////////
+        
     }
 
 })();

--- a/src/main/resources/static/src/app/quick-panel/tabs/recentwiki/recentwiki.html
+++ b/src/main/resources/static/src/app/quick-panel/tabs/recentwiki/recentwiki.html
@@ -1,3 +1,5 @@
 <div class="ph-16 border-bottom" layout="row" layout-align="space-between center">
     <div class="h3" style="margin-top: 18px; margin-bottom: 18px;">Recent wiki change</div>
 </div>
+
+<a ng-click ="vm.wikigo(wikipath.Link)" ng-repeat="wikipath in vm.wikihistory.Link">{{wikipath.Title}}</br></a>

--- a/src/main/resources/static/src/app/toolbar/toolbar.controller.js
+++ b/src/main/resources/static/src/app/toolbar/toolbar.controller.js
@@ -7,7 +7,7 @@
         .controller('ToolbarController', ToolbarController);
 
     /** @ngInject */
-    function ToolbarController($rootScope, $q, $state, $timeout, $mdSidenav, $translate, $mdToast, msNavigationService)
+    function ToolbarController($rootScope, $q, $state, $timeout, $mdSidenav, $translate, $mdToast, msNavigationService, $sessionStorage)
     {
         var vm = this;
 
@@ -35,7 +35,7 @@
             }
         ];
 
-        vm.userID = $rootScope.email;
+        vm.userID = $sessionStorage.get('useremail');
 
         vm.languages = {
             en: {
@@ -109,6 +109,7 @@
          */
         function logout()
         {
+            $sessionStorage.empty();
             $state.go('login');
             // Do logout here..
         }

--- a/src/main/resources/static/src/index.html
+++ b/src/main/resources/static/src/index.html
@@ -30,7 +30,7 @@
         your browser</a> to improve your experience.</p>
     <![endif]-->
     <!-- Daum map api -->
-    <script type="text/javascript" src="//apis.daum.net/maps/maps3.js?apikey=9fd512da64793dd87dc793f65327e388"></script>
+    <script type="text/javascript" src="//apis.daum.net/maps/maps3.js?apikey=9fd512da64793dd87dc793f65327e388&libraries=services,clusterer,drawing"></script>
     <body md-theme="{{vm.themes.active.name}}" md-theme-watch ng-controller="IndexController as vm"
           class="{{state.current.bodyClass || ''}}">
 


### PR DESCRIPTION
최근 수정 항목의 경우 크로스 오리진 문제때문에 일단 주석처리 해뒀습니다. index.route에서 RecentwikiData에 있는 주석 (62번째줄)을 원래대로 돌리고 quick-panel.controller에 있는 18번째줄 주석과 function init()안에 있는 주석을 원래대로 돌리면 최근 수정 항목을 볼 수 있습니다.
다이얼로그에서 위키로 갈때는 $rootScope.wikipath 에 주소값을 넣고 $state.go하시면 됩니다.